### PR TITLE
Enable CSS for preview mode

### DIFF
--- a/v1/components/MarkdownEditor.tsx
+++ b/v1/components/MarkdownEditor.tsx
@@ -1,6 +1,6 @@
 import { FOCUS_EVENTS, handleFieldFocusEvent } from "@/methods/handleFieldFocusEvent"
 import { useAgilityAppSDK, contentItemMethods, useResizeHeight } from "@agility/app-sdk"
-import React, { useState, useEffect } from "react"
+import React from "react"
 
 import SimpleMDE from "react-simplemde-editor"
 
@@ -10,25 +10,9 @@ const MarkdownEditor = () => {
 
 	const markdownValues = fieldValue
 
-	const [, setMarkdownHeight] = useState(500)
-
 	const onChange = (value: string) => {
 		contentItemMethods.setFieldValue({ value })
 	}
-
-	// listen for simple-mde resizing events
-	useEffect(() => {
-		const mdeSizeElm = document.querySelector<HTMLElement>(".CodeMirror-sizer")
-		if (!mdeSizeElm) return
-		const observer = new ResizeObserver((entries) => {
-			const entry = entries[0]
-			if (!entry) return
-			setMarkdownHeight(entry.contentRect.height)
-		})
-		observer.observe(mdeSizeElm)
-
-		return () => observer.disconnect()
-	}, [])
 
 	return (
 		<div ref={containerRef} className="min-h-[400px] bg-white">

--- a/v1/styles/globals.css
+++ b/v1/styles/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.editor-preview,
+.editor-preview-side {
+	@apply prose max-w-none;
+}


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-338

Fix markdown preview styling stripped by Tailwind preflight

EasyMDE renders two preview elements: .editor-preview (full-screen) and .editor-preview-side (side-by-side). Both rely on browser default styles for headings, lists, blockquotes, etc. Tailwind's preflight resets those defaults globally, leaving the preview pane unstyled while CodeMirror's source pane retained its own scoped styles — making them appear swapped.

Scoping @tailwindcss/typography's prose class to both preview elements (outside any @layer, so it runs after preflight) restores heading sizes, list bullets, font weights, and margins inside the preview only, with no impact on the rest of the app.

### To test:
1. download the package and run it locally
2. Then use ngrok and install it as a private app to an instance
3. Add the power field's markdown editor to any model
4. Play around with the field in the model in side by side view
5. Ensure that the styling is showing up on the right hand side (The styling will remain on the left hand side due to a limitation in the package react-simplemde-editor). I have opened a story to investigate other librarys that we can use.