### PR TITLE
Case insensitive title listener

### DIFF
--- a/v1/components/FriendlySlugField.tsx
+++ b/v1/components/FriendlySlugField.tsx
@@ -41,9 +41,13 @@ const FriendlyURLField = () => {
 	};
 	const hasBeenSaved = !!!(contentItem && contentItem?.contentID < 0);
 
+	const titleFieldName = contentItem?.values
+		? Object.keys(contentItem.values).find((k) => k.toLowerCase() === "title") ?? "Title"
+		: "Title";
+
 	const intializeTitleFieldListener = () => {
 		contentItemMethods.addFieldListener({
-			fieldName: "Title",
+			fieldName: titleFieldName,
 			onChange: (t) => {
 				setCurrentTitle(t);
 				contentItemMethods?.getContentItem()?.then((ci) => {


### PR DESCRIPTION
Part of https://agilitycms.atlassian.net/browse/PROD-2220

The changes in this PR will make the friendly url slug listen to the title field with case insensitivity. Here's a video of it working in local development. The title field has a reference name of `TITLE`

https://github.com/user-attachments/assets/6993cd81-7b90-4813-a053-507fa05cc705